### PR TITLE
Update lesson 6

### DIFF
--- a/6/README.md
+++ b/6/README.md
@@ -171,8 +171,10 @@ To check out the original branch and stop rebasing, run "git rebase --abort".
 git branch -D branch_name
 ````
 
-服务器端的分支，可以在web界面删除。
-
+服务器端的分支，可以在web界面删除，也可以使用下面的命令删除：
+```
+git push origin :branch_name
+```
 
 
 ## 课程完成检查点


### PR DESCRIPTION
添加“使用命令行删除远程分支”的相关内容。
***
命令原型是：`git push <repository> <src>:<dst>`
`git push origin :branch_name` 这条命令的含义是使用一个空引用替代远程分支。